### PR TITLE
fix: mantle needs libedit to link mount/cephfs libraries

### DIFF
--- a/builder-mantle/Dockerfile
+++ b/builder-mantle/Dockerfile
@@ -3,7 +3,7 @@ FROM ivotron/cephdev-build:latest
 MAINTAINER Michael Sevilla <mikesevilla3@gmail.com>
 
 RUN apt-get update && \
-    apt-get install -y lua5.2 liblua5.2-dev && \
+    apt-get install -y lua5.2 liblua5.2-dev libedit-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* debian/
 


### PR DESCRIPTION
Signed-off-by: Michael Sevilla mikesevilla3@gmail.com
